### PR TITLE
Fix fatal error accessing container

### DIFF
--- a/src/Stats/Controllers/SubmitController.php
+++ b/src/Stats/Controllers/SubmitController.php
@@ -34,7 +34,7 @@ class SubmitController extends DefaultController
 		$data["server_os"] = $input->getString("server_os");
 
 		/** @var \Stats\Tables\StatsTable $table */
-		$table = $this->container->buildSharedObject("Stats\\Tables\\StatsTable");
+		$table = $this->getContainer()->buildSharedObject("Stats\\Tables\\StatsTable");
 
 		if (empty($data['unique_id']) || ! $table->save($data))
 		{


### PR DESCRIPTION
The container variable is private so it cannot be accessed directly. This generates the error 

```Call to a member function buildSharedObject() on a non-object```

Need to use the getContainer() method. This PR makes that change.