### PR TITLE
Remove boot.php

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1,7 +1,0 @@
-<?php
-
-const APPROOT = __DIR__;
-
-define("JPATH_TEMPLATES", APPROOT . "/src/templates");
-
-require APPROOT . "/vendor/autoload.php";

--- a/www/index.php
+++ b/www/index.php
@@ -1,18 +1,23 @@
 <?php
 
-require __DIR__ . "/../boot.php";
+// Application constants
+define('APPROOT',      dirname(__DIR__));
+define("JPATH_TEMPLATES", APPROOT . "/src/templates");
 
-use Joomla\DI\Container;
-use Stats\Providers\ConfigServiceProvider;
-use Stats\Providers\DatabaseServiceProvider;
-use Stats\Providers\TwigServiceProvider;
+// Ensure we've initialized Composer
+if (!file_exists(APPROOT . '/vendor/autoload.php'))
+{
+	header('HTTP/1.1 500 Internal Server Error', null, 500);
+	echo 'Composer is not set up properly, please run "composer install".';
+	exit;
+}
 
-$container = (new Container)
-	->registerServiceProvider(new ConfigServiceProvider(APPROOT . "/etc/config.json"))
-	->registerServiceProvider(new DatabaseServiceProvider);
+$container = (new Joomla\DI\Container)
+	->registerServiceProvider(new Stats\Providers\ConfigServiceProvider(APPROOT . "/etc/config.json"))
+	->registerServiceProvider(new Stats\Providers\DatabaseServiceProvider);
 
 $app = $container->alias('app', 'Stats\Application')->buildObject('Stats\Application');
-$container->registerServiceProvider(new TwigServiceProvider);
+$container->registerServiceProvider(new Stats\Providers\TwigServiceProvider);
 $app->setContainer($container);
 
 $router = (new Stats\Router($app->input))


### PR DESCRIPTION
Move the functionality in ```boot.php``` into ```index.php```

This also gives a full error response when composer isn't installed