### PR TITLE
Change of PK

### DIFF
--- a/etc/mysql.sql
+++ b/etc/mysql.sql
@@ -1,10 +1,9 @@
 CREATE TABLE IF NOT EXISTS `jos_jstats` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
   `unique_id` varchar(32) NOT NULL,
   `php_version` varchar(255) NOT NULL,
   `db_type` varchar(255) NOT NULL,
   `db_version` varchar(255) NOT NULL,
   `cms_version` varchar(255) NOT NULL,
   `server_os` varchar(255) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`unique_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/src/Models/StatsModel.php
+++ b/src/Models/StatsModel.php
@@ -53,7 +53,6 @@ class StatsModel extends AbstractDatabaseModel
 
 		if ($recordExists)
 		{
-			$data->unique_id = $recordExists;
 			$db->updateObject('#__jstats', $data, ['unique_id']);
 		}
 		else

--- a/src/Models/StatsModel.php
+++ b/src/Models/StatsModel.php
@@ -46,19 +46,19 @@ class StatsModel extends AbstractDatabaseModel
 		// Check if a row exists for this unique ID and update the existing record if so
 		$recordExists = $db->setQuery(
 			$db->getQuery(true)
-				->select('id')
+				->select('unique_id')
 				->from('#__jstats')
 				->where('unique_id = ' . $db->quote($data->unique_id))
 		)->loadResult();
 
 		if ($recordExists)
 		{
-			$data->id = $recordExists;
-			$db->updateObject('#__jstats', $data, ['id']);
+			$data->unique_id = $recordExists;
+			$db->updateObject('#__jstats', $data, ['unique_id']);
 		}
 		else
 		{
-			$db->insertObject('#__jstats', $data, ['id']);
+			$db->insertObject('#__jstats', $data, ['unique_id']);
 		}
 	}
 }


### PR DESCRIPTION
Used a natural PK ```unique_id```  instead of  ```id```
As discussed on Sql WG on glip
Is more performant to use a natural PK like ```unique_id``` instead of ```id```
cause we need to know if an ```unique_id``` already exits to decide if insert or update the ```#__jstats``` table
so is better to use ```unique_id``` as a PK instead of adding another key

ps
The perfomance may vary  a lot depending on server settings, so if we are concerned about performance
I think this is a good use case to use Redis instead is superfast

