### PR TITLE
Add a modified date column to the schema

### DIFF
--- a/etc/mysql.sql
+++ b/etc/mysql.sql
@@ -5,5 +5,6 @@ CREATE TABLE IF NOT EXISTS `jos_jstats` (
   `db_version` varchar(255) NOT NULL,
   `cms_version` varchar(255) NOT NULL,
   `server_os` varchar(255) NOT NULL,
+  `modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   PRIMARY KEY (`unique_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/src/Models/StatsModel.php
+++ b/src/Models/StatsModel.php
@@ -43,6 +43,9 @@ class StatsModel extends AbstractDatabaseModel
 	{
 		$db = $this->getDb();
 
+		// Set the modified date of the record
+		$data->modified = (new \DateTime('now', new \DateTimeZone('UTC')))->format($db->getDateFormat());
+
 		// Check if a row exists for this unique ID and update the existing record if so
 		$recordExists = $db->setQuery(
 			$db->getQuery(true)


### PR DESCRIPTION
This can be used as an admin tool to gauge stale records when processing the data.  The API endpoints will not return this with the processed data.