### PR TITLE
Regular expression to get versions

### DIFF
--- a/src/Controllers/SubmitControllerCreate.php
+++ b/src/Controllers/SubmitControllerCreate.php
@@ -57,7 +57,7 @@ class SubmitControllerCreate extends AbstractController
 		$data = array_map(
 			function ($value)
 			{
-				return preg_replace('/[^0-9.]/', '', $value);
+				return preg_match('/\d+(?:\.\d+)+/', $value, $matches) ? $matches[0] : $value;
 			},
 			$data
 		);


### PR DESCRIPTION
This solves the issue with versions like: `3.5.0-beta2` returning `3.5.02`. Sample test versions:

```
	'3.5',
	'3.5.10-dev2',
	'12.4.10-dev1',
	'3.12.0-dev',
	'4.50'
```

Return:

```
3.5
3.5.10
12.4.10
3.12.0
4.50
```